### PR TITLE
Add mask mapping support (API) & expose global effect weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v1.3.7 - 2024 Apr.14
+- **Global Effect Weight** Slider by. <ins>ramyma</ins>
+- **Mask API** by. <ins>ramyma</ins>
+
 ### v1.3.6 - 2024 Apr.12
 - **Cache** DOM Elements
 

--- a/scripts/couple_mapping.py
+++ b/scripts/couple_mapping.py
@@ -1,6 +1,11 @@
 from modules.prompt_parser import SdConditioning
+from modules import images
 from scripts.couple_ui import parse_mapping
 import torch
+import base64
+import numpy as np
+from PIL import Image
+import io
 
 
 def empty_tensor(H: int, W: int):
@@ -87,6 +92,63 @@ def basic_mapping(
 
         ARGs[f"cond_{tile + 1}"] = pos_cond
         ARGs[f"mask_{tile + 1}"] = mask.unsqueeze(0)
+
+    if background == "Last Line":
+        ARGs[f"mask_{LINE_COUNT}"] = (
+            torch.ones((HEIGHT, WIDTH)) * BG_WEIGHT
+        ).unsqueeze(0)
+
+    return ARGs
+
+def convert_base64_image_to_tensor(base_64_image_string: str, WIDTH: int, HEIGHT: int):
+    image_bytes = base64.b64decode(base_64_image_string)
+    image = Image.open(io.BytesIO(image_bytes))
+    image = image.convert("L")
+    if image.width != WIDTH or image.height != HEIGHT:
+        image = image.resize((WIDTH, HEIGHT), resample=images.LANCZOS)
+    image = np.array(image).astype(np.float32) / 255.0
+    image = torch.from_numpy(image)[None,]
+    return image
+
+def mask_mapping(
+    sd_model,
+    couples: list,
+    WIDTH: int,
+    HEIGHT: int,
+    LINE_COUNT: int,
+    mapping: list[dict],
+    background: str,
+    BG_WEIGHT: float,
+):
+    mapping = [{"mask": convert_base64_image_to_tensor(m["mask"], WIDTH, HEIGHT), "weight": m["weight"]} for m in mapping] if mapping else mapping
+
+    ARGs: dict = {}
+    IS_SDXL: bool = hasattr(
+        sd_model.forge_objects.unet.model.diffusion_model, "label_emb"
+    )
+
+    for layer in range(LINE_COUNT):
+        mask = torch.zeros((HEIGHT, WIDTH))
+
+        # ===== Cond =====
+        texts = SdConditioning([couples[layer]], False, WIDTH, HEIGHT, None)
+        cond = sd_model.get_learned_conditioning(texts)
+        pos_cond = [[cond["crossattn"]]] if IS_SDXL else [[cond]]
+        # ===== Cond =====
+
+        # ===== Mask =====
+        if background == "First Line":
+            if layer == 0:
+                mask = torch.ones((HEIGHT, WIDTH)) * BG_WEIGHT
+            else:
+                mask = mapping[layer-1]["mask"] * mapping[layer-1]["weight"]
+        else:
+            mask = mapping[layer]["mask"] * mapping[layer]["weight"]
+        # ===== Mask =====
+
+        ARGs[f"cond_{layer + 1}"] = pos_cond
+        ARGs[f"mask_{layer + 1}"] = mask.unsqueeze(0) if mask.dim() == 2 else mask
+
 
     if background == "Last Line":
         ARGs[f"mask_{LINE_COUNT}"] = (

--- a/scripts/couple_ui.py
+++ b/scripts/couple_ui.py
@@ -209,10 +209,12 @@ def couple_UI(script, is_img2img: bool, title: str):
                     label="Global Effect",
                     value="None",
                 )
+
                 background_weight = gr.Slider(
                     minimum=0.1,
-                    maximum=1,
-                    value=0.5,
+                    maximum=1.0,
+                    step=0.1,
+                    value=1.0,
                     label="Global Effect Weight",
                 )
 
@@ -327,6 +329,7 @@ def couple_UI(script, is_img2img: bool, title: str):
             (separator, "forge_couple_separator"),
             (mode, "forge_couple_mode"),
             (mapping, "forge_couple_mapping"),
+            (background_weight, "forge_couple_background_weight"),
         ]
 
         for comp, name in script.infotext_fields:
@@ -336,4 +339,12 @@ def couple_UI(script, is_img2img: bool, title: str):
         for comp in (manual_idx, manual_field):
             comp.do_not_save_to_config = True
 
-        return [enable, direction, background, separator, mode, mapping, background_weight]
+        return [
+            enable,
+            direction,
+            background,
+            separator,
+            mode,
+            mapping,
+            background_weight,
+        ]

--- a/scripts/couple_ui.py
+++ b/scripts/couple_ui.py
@@ -209,6 +209,12 @@ def couple_UI(script, is_img2img: bool, title: str):
                     label="Global Effect",
                     value="None",
                 )
+                background_weight = gr.Slider(
+                    minimum=0.1,
+                    maximum=1,
+                    value=0.5,
+                    label="Global Effect Weight",
+                )
 
         with gr.Group(visible=False, elem_classes="fc_adv") as adv_settings:
             mapping = gr.Dataframe(
@@ -330,4 +336,4 @@ def couple_UI(script, is_img2img: bool, title: str):
         for comp in (manual_idx, manual_field):
             comp.do_not_save_to_config = True
 
-        return [enable, direction, background, separator, mode, mapping]
+        return [enable, direction, background, separator, mode, mapping, background_weight]

--- a/scripts/forge_couple.py
+++ b/scripts/forge_couple.py
@@ -1,13 +1,18 @@
 from modules import scripts
 import re
 
-from scripts.couple_mapping import empty_tensor, basic_mapping, advanced_mapping, mask_mapping
+from scripts.couple_mapping import (
+    empty_tensor,
+    basic_mapping,
+    advanced_mapping,
+    mask_mapping,
+)
 from scripts.couple_ui import couple_UI, validata_mapping, parse_mapping, hook_component
 
 from scripts.attention_couple import AttentionCouple
 forgeAttentionCouple = AttentionCouple()
 
-VERSION = "1.3.6"
+VERSION = "1.3.7"
 
 
 class ForgeCouple(scripts.Script):
@@ -69,8 +74,10 @@ class ForgeCouple(scripts.Script):
             print(
                 f"\n\n[Couple] Not Enough Lines in Prompt...\nCurrent: {len(couples)} / Required: {3 if background != 'None' else 2}\n\n"
             )
-        if mode == "Mask": 
-            if not mapping or len(mapping) != len(couples)- (1 if background != "None" else 0):
+        if mode == "Mask":
+            if not mapping or len(mapping) != len(couples) - (
+                1 if background != "None" else 0
+            ):
                 print("\n\n[Couple] Number of Couples and Masks is not the same...\n\n")
                 self.couples = None
                 return
@@ -115,10 +122,11 @@ class ForgeCouple(scripts.Script):
             "\n" if not separator.strip() else separator.strip()
         )
         p.extra_generation_params["forge_couple_mode"] = mode
+        p.extra_generation_params["forge_couple_background_weight"] = background_weight
         if mode == "Basic":
             p.extra_generation_params["forge_couple_direction"] = direction
             p.extra_generation_params["forge_couple_background"] = background
-        else:
+        elif mode == "Advanced":
             p.extra_generation_params["forge_couple_mapping"] = mapping
         # ===== Infotext =====
 
@@ -134,7 +142,9 @@ class ForgeCouple(scripts.Script):
 
         if mode == "Basic":
             TILE_WEIGHT: float = 1.25 if background == "None" else 1.0
-            BG_WEIGHT: float = 0.0 if background == "None" else (0.1 if background_weight == 0.0 else background_weight or 0.5)
+            BG_WEIGHT: float = (
+                0.0 if background == "None" else max(0.1, background_weight)
+            )
 
             TILE_SIZE: int = (
                 (WIDTH if IS_HORIZONTAL else HEIGHT) - 1
@@ -156,17 +166,21 @@ class ForgeCouple(scripts.Script):
                 BG_WEIGHT,
             )
 
-        elif mode== "Mask":
-            BG_WEIGHT: float = 0.0 if background == "None" else (0.1 if background_weight == 0.0 else background_weight or 0.5)
-            
-            ARGs = mask_mapping(p.sd_model,
+        elif mode == "Mask":
+            BG_WEIGHT: float = (
+                0.0 if background == "None" else max(0.1, background_weight)
+            )
+
+            ARGs = mask_mapping(
+                p.sd_model,
                 self.couples,
                 WIDTH,
                 HEIGHT,
                 LINE_COUNT,
                 mapping,
                 background,
-                BG_WEIGHT)
+                BG_WEIGHT,
+            )
         else:
             ARGs = advanced_mapping(p.sd_model, self.couples, WIDTH, HEIGHT, mapping)
         # ===== Tiles =====

--- a/scripts/forge_couple.py
+++ b/scripts/forge_couple.py
@@ -1,7 +1,7 @@
 from modules import scripts
 import re
 
-from scripts.couple_mapping import empty_tensor, basic_mapping, advanced_mapping
+from scripts.couple_mapping import empty_tensor, basic_mapping, advanced_mapping, mask_mapping
 from scripts.couple_ui import couple_UI, validata_mapping, parse_mapping, hook_component
 
 from scripts.attention_couple import AttentionCouple
@@ -44,6 +44,7 @@ class ForgeCouple(scripts.Script):
         separator: str,
         mode: str,
         mapping: list,
+        background_weight: float,
         *args,
         **kwargs,
     ):
@@ -68,6 +69,13 @@ class ForgeCouple(scripts.Script):
             print(
                 f"\n\n[Couple] Not Enough Lines in Prompt...\nCurrent: {len(couples)} / Required: {3 if background != 'None' else 2}\n\n"
             )
+        if mode == "Mask": 
+            if not mapping or len(mapping) != len(couples)- (1 if background != "None" else 0):
+                print("\n\n[Couple] Number of Couples and Masks is not the same...\n\n")
+                self.couples = None
+                return
+        elif len(couples) < (3 if background != "None" else 2):
+            print("\n\n[Couple] Not Enough Lines in Prompt...\n\n")
             self.couples = None
             return
 
@@ -93,6 +101,7 @@ class ForgeCouple(scripts.Script):
         separator: str,
         mode: str,
         mapping: list,
+        background_weight: float,
         *args,
         **kwargs,
     ):
@@ -125,7 +134,7 @@ class ForgeCouple(scripts.Script):
 
         if mode == "Basic":
             TILE_WEIGHT: float = 1.25 if background == "None" else 1.0
-            BG_WEIGHT: float = 0.0 if background == "None" else 0.5
+            BG_WEIGHT: float = 0.0 if background == "None" else (0.1 if background_weight == 0.0 else background_weight or 0.5)
 
             TILE_SIZE: int = (
                 (WIDTH if IS_HORIZONTAL else HEIGHT) - 1
@@ -147,11 +156,23 @@ class ForgeCouple(scripts.Script):
                 BG_WEIGHT,
             )
 
+        elif mode== "Mask":
+            BG_WEIGHT: float = 0.0 if background == "None" else (0.1 if background_weight == 0.0 else background_weight or 0.5)
+            
+            ARGs = mask_mapping(p.sd_model,
+                self.couples,
+                WIDTH,
+                HEIGHT,
+                LINE_COUNT,
+                mapping,
+                background,
+                BG_WEIGHT)
         else:
             ARGs = advanced_mapping(p.sd_model, self.couples, WIDTH, HEIGHT, mapping)
         # ===== Tiles =====
 
-        assert len(ARGs.keys()) // 2 == LINE_COUNT
+        if mode != "Mask":
+            assert len(ARGs.keys()) // 2 == LINE_COUNT
 
         base_mask = empty_tensor(HEIGHT, WIDTH)
         patched_unet = forgeAttentionCouple.patch_unet(unet, base_mask, ARGs)


### PR DESCRIPTION
1. Expose `Global Effect Weight` slider, to define background weight dynamically
2. Add `Mask` mode which can be used through API to define mask mappings with weights

Here's a payload example with mask mappings and global effect weight:
```
"forge couple": {
    "args": [
      # Enabled
      true,
      # Direction
      "Horizontal",
      # Background
      "First Line",
      # Separator
      "<SEP>",
      # Mode
      "Mask",
      # Mappings
      [
        {
          "mask": "BASE64_IMAGE_STRING",
          "weight": 1
        },
        {
          "mask": "BASE64_IMAGE_STRING",
          "weight": 1
        }
      ],
      # Background weight 
      0.5
    ]
  }
```