### PR TITLE
Implement dynamic weight formula in Advanced mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v2.0.4 - 2024 Aug. 26
+- Implement **Dynamic Weight Formulas in Advanced Mode**
+
 ### v2.0.3 - 2024 Aug.19
 - Minor **Optimization**
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ Were these automated and equally-sized tiles not sufficient for your needs? Now 
 
 - **Entries:**
     - Each row contains a range for **x** axis, a range for **y** axis, a **weight**, as well as the corresponding **line** of prompt
+    - **weight** can be a float, or a formula for dynamic weight
+        - Dynamic weight formula starts with with **=**
+        - **x** and **y** are available as variables (case-sensitive, use lowercase)
+        - **eg.** two whole-image regions with weight `=x` and `=(1-x)` will linearly interpolate between prompts, moving across the image from left to right
+        - Common mathematical functions are also available in Dynamic weight formulas: **sin**, **cos**, **tan**, **exp**, **log**, **sqrt**, **abs**, **max**, **min**
     - The range should be within `0.0` ~ `1.0`, representing the **percentage** of the full width/height
         - **eg.** `0.0` to `1.0` would span across the entire axis
     - **x** axis is from left to right; **y** axis is from top to bottom

--- a/javascript/couple.js
+++ b/javascript/couple.js
@@ -111,7 +111,13 @@ class ForgeCouple {
 
         const vals = Array.from(rows, row => {
             return Array.from(row.querySelectorAll("td"))
-                .slice(0, -1).map(cell => parseFloat(cell.textContent));
+                .slice(0, -1).map((cell, index) => {
+                    if (index === 4) {
+                        const value = cell.textContent.trim();
+                        return value.startsWith('=') ? value : parseFloat(value);
+                    }
+                    return parseFloat(cell.textContent);
+                });
         });
 
         const json = JSON.stringify(vals);

--- a/javascript/dataframe.js
+++ b/javascript/dataframe.js
@@ -112,11 +112,17 @@ class ForgeCoupleDataframe {
 
             updateInput(this.#promptField);
         } else {
-            var val = this.#clamp01(cell.textContent,
-                Array.from(cell.parentElement.children).indexOf(cell) === 4
-            );
-            val = Math.round(val / 0.01) * 0.01;
-            cell.textContent = Number(val).toFixed(2);
+            const isWeight = Array.from(cell.parentElement.children).indexOf(cell) === 4;
+            let val = cell.textContent.trim();
+
+            if (isWeight && val.startsWith('='))
+                cell.textContent = val;
+            else {
+                val = this.#clamp01(val, isWeight);
+                val = Math.round(val / 0.01) * 0.01;
+                cell.textContent = Number(val).toFixed(2);
+            }
+
             ForgeCouple.onSelect(this.#mode);
             ForgeCouple.onEntry(this.#mode);
         }
@@ -366,15 +372,16 @@ class ForgeCoupleDataframe {
         });
     }
 
-    /** @param {number} @param {boolean} w @returns {number} */
-    #clamp01(v, w) {
-        var val = parseFloat(v);
+    /** @param {number} v @param {boolean} isWeight @returns {number|string} */
+    #clamp01(v, isWeight) {
+        let val = parseFloat(v);
+
         if (Number.isNaN(val))
             val = 0.0;
 
         return Math.min(
-            Math.max(val, w ? -10.0 : 0.0),
-            w ? 10.0 : 1.0
+            Math.max(val, isWeight ? -10.0 : 0.0),
+            isWeight ? 10.0 : 1.0
         );
     }
 

--- a/lib_couple/mapping.py
+++ b/lib_couple/mapping.py
@@ -5,6 +5,7 @@ from io import BytesIO as bIO
 from PIL import Image
 import numpy as np
 import torch
+from typing import List, Union, Tuple
 
 
 def empty_tensor(H: int, W: int):
@@ -65,21 +66,59 @@ def basic_mapping(
     return ARGs
 
 
-def advanced_mapping(sd_model, couples: list, WIDTH: int, HEIGHT: int, mapping: list):
-    assert len(couples) == len(mapping)
+def safe_eval(formula: str, X: torch.Tensor, Y: torch.Tensor) -> torch.Tensor:
+    safe_dict = {
+        "sin": torch.sin,
+        "cos": torch.cos,
+        "tan": torch.tan,
+        "exp": torch.exp,
+        "log": torch.log,
+        "sqrt": torch.sqrt,
+        "abs": torch.abs,
+        "max": torch.max,
+        "min": torch.min,
+    }
+    return eval(formula, {"__builtins__": None}, {**safe_dict, "x": X, "y": Y})
+
+
+def create_formula_mask(formula: str, width: int, height: int, x1: float, x2: float, y1: float, y2: float) -> torch.Tensor:
+    try:
+        x = torch.linspace(0, 1, width)
+        y = torch.linspace(0, 1, height)
+        X, Y = torch.meshgrid(x, y, indexing='xy')
+
+        mask = safe_eval(formula, X, Y)
+
+        full_mask = torch.zeros((height, width))
+        x_from, x_to = int(width * x1), int(width * x2)
+        y_from, y_to = int(height * y1), int(height * y2)
+        full_mask[y_from:y_to, x_from:x_to] = mask[y_from:y_to, x_from:x_to]
+
+        return full_mask
+    except Exception as e:
+        print(f"Error evaluating formula '{formula}': {str(e)}")
+        return torch.zeros((height, width))
+
+
+def advanced_mapping(sd_model, couples: List[str], WIDTH: int, HEIGHT: int, mapping: List[List[Union[float, str]]]) -> dict:
+    assert len(couples) == len(mapping), "Number of couples must match number of mappings"
 
     ARGs: dict = {}
-    IS_SDXL: bool = hasattr(
-        sd_model.forge_objects.unet.model.diffusion_model, "label_emb"
-    )
+    IS_SDXL: bool = hasattr(sd_model.forge_objects.unet.model.diffusion_model, "label_emb")
 
-    for tile_index, (x1, x2, y1, y2, w) in enumerate(mapping):
-        mask = torch.zeros((HEIGHT, WIDTH))
+    for tile_index, mapping_entry in enumerate(mapping):
+        if len(mapping_entry) != 5:
+            raise ValueError(f"Invalid mapping entry for tile {tile_index}. Expected 5 values, got {len(mapping_entry)}")
 
-        x_from = int(WIDTH * x1)
-        x_to = int(WIDTH * x2)
-        y_from = int(HEIGHT * y1)
-        y_to = int(HEIGHT * y2)
+        x1, x2, y1, y2, w = mapping_entry
+
+        try:
+            x1, x2, y1, y2 = map(float, (x1, x2, y1, y2))
+        except ValueError as e:
+            raise ValueError(f"Invalid coordinate values for tile {tile_index}: {x1}, {x2}, {y1}, {y2}. Error: {str(e)}")
+
+        if not (0 <= x1 < x2 <= 1 and 0 <= y1 < y2 <= 1):
+            raise ValueError(f"Invalid coordinate range for tile {tile_index}: {x1}, {x2}, {y1}, {y2}. Must be 0 <= x1 < x2 <= 1 and 0 <= y1 < y2 <= 1")
 
         # ===== Cond =====
         texts = SdConditioning([couples[tile_index]], False, WIDTH, HEIGHT, None)
@@ -88,7 +127,18 @@ def advanced_mapping(sd_model, couples: list, WIDTH: int, HEIGHT: int, mapping: 
         # ===== Cond =====
 
         # ===== Mask =====
-        mask[y_from:y_to, x_from:x_to] = w
+        if isinstance(w, str) and w.startswith('='):
+            mask = create_formula_mask(w[1:], WIDTH, HEIGHT, x1, x2, y1, y2)
+        else:
+            try:
+                w_float = float(w)
+            except ValueError:
+                raise ValueError(f"Weight must be a numeric value or a formula string starting with =. Got: {w}")
+
+            mask = torch.zeros((HEIGHT, WIDTH))
+            x_from, x_to = int(WIDTH * x1), int(WIDTH * x2)
+            y_from, y_to = int(HEIGHT * y1), int(HEIGHT * y2)
+            mask[y_from:y_to, x_from:x_to] = w_float
         # ===== Mask =====
 
         ARGs[f"cond_{tile_index + 1}"] = pos_cond


### PR DESCRIPTION
This provides the option to use dynamic mask weight to more smoothly blend the conditioning; for example, you can set the weight as `=exp(-((x-0.5)**2 + (y-0.5)**2) / (2 * 0.15**2))` to give it a Gaussian distribution (bell durve) that falls off smoothly as it moves away from the center of the image, or use two regions with respective weights `=y` and `=(1-y)` to gradually transition between the prompts as you move from top to bottom along the image.