### PR TITLE
Provide possibility to include or exclude Common definition to prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v4.0.3 - 2025 Oct.02
+- Implement **Include Definitions in Prompt** by. <ins>Waseem9287</ins>
+
 ### v4.0.2 - 2025 Mar.31
 - Improved **Compatibility** for A1111
 

--- a/README.md
+++ b/README.md
@@ -242,9 +242,8 @@ If you have multiple characters that share the same outfits, poses, or expressio
 4. Then, surround the whole thing with your chosen brackets *(**eg.** `{cloth:t-shirt, jacket, jeans}`)*
 5. Finally, you can now use the key to recall the common prompts in other lines *(**ie.** `{cloth}`)*
 
-- **TL;DR:** If you have `{foo:bar}` in your prompt, every occurrence of `{foo}` 
-  (and optionally the original `{foo:bar}` if *Include Definitions to Prompt* is enabled) 
-  will be replaced with `bar` during the generation.
+- **TL;DR:** If you have `{foo:bar}` in your prompt, every occurrence of `{foo}` *(and the original `{foo:bar}`)* will be replaced with `bar` during the generation
+    - You can also omit the original `{foo:bar}` by disabling the `Include Definitions in Prompt` option
 
 > [!IMPORTANT]
 > - The key has to be unique

--- a/README.md
+++ b/README.md
@@ -242,7 +242,9 @@ If you have multiple characters that share the same outfits, poses, or expressio
 4. Then, surround the whole thing with your chosen brackets *(**eg.** `{cloth:t-shirt, jacket, jeans}`)*
 5. Finally, you can now use the key to recall the common prompts in other lines *(**ie.** `{cloth}`)*
 
-- **TL;DR:** If you have `{foo:bar}` in your prompt, every occurrence of `{foo}` *(and the original `{foo:bar}`)* will be replaced with `bar` during the generation
+- **TL;DR:** If you have `{foo:bar}` in your prompt, every occurrence of `{foo}` 
+  (and optionally the original `{foo:bar}` if *Include Definitions to Prompt* is enabled) 
+  will be replaced with `bar` during the generation.
 
 > [!IMPORTANT]
 > - The key has to be unique

--- a/lib_couple/ui.py
+++ b/lib_couple/ui.py
@@ -188,11 +188,12 @@ def couple_ui(script, is_img2img: bool, title: str, unpatch: Callable):
         ):
             with gr.Row():
                 common_parser = gr.Radio(
-                    ("off", "{ }", "< >"), label="Syntax", value="{ }", scale=4
+                    ("off", "{ }", "< >"), label="Syntax", value="{ }", scale=3
                 )
-            with gr.Row():
-                common_definitions_in_prompt = gr.Checkbox(True, label="Include Common Definitions to Prompt", scale=2)
-                common_debug = gr.Checkbox(False, label="Debug", scale=2)
+                def_in_prompt = gr.Checkbox(
+                    True, label="Include Definitions in Prompt", scale=3
+                )
+                common_debug = gr.Checkbox(False, label="Debug", scale=1)
                 common_debug.do_not_save_to_config = True
 
         def on_mode_change(choice: str):
@@ -247,6 +248,6 @@ def couple_ui(script, is_img2img: bool, title: str, unpatch: Callable):
         mapping,
         common_parser,
         common_debug,
-        common_definitions_in_prompt,
+        def_in_prompt,
         *tile_args,
     ]

--- a/lib_couple/ui.py
+++ b/lib_couple/ui.py
@@ -190,7 +190,9 @@ def couple_ui(script, is_img2img: bool, title: str, unpatch: Callable):
                 common_parser = gr.Radio(
                     ("off", "{ }", "< >"), label="Syntax", value="{ }", scale=4
                 )
-                common_debug = gr.Checkbox(False, label="Debug", scale=1)
+            with gr.Row():
+                common_definitions_in_prompt = gr.Checkbox(True, label="Include Common Definitions to Prompt", scale=2)
+                common_debug = gr.Checkbox(False, label="Debug", scale=2)
                 common_debug.do_not_save_to_config = True
 
         def on_mode_change(choice: str):
@@ -245,5 +247,6 @@ def couple_ui(script, is_img2img: bool, title: str, unpatch: Callable):
         mapping,
         common_parser,
         common_debug,
+        common_definitions_in_prompt,
         *tile_args,
     ]

--- a/scripts/forge_couple.py
+++ b/scripts/forge_couple.py
@@ -25,7 +25,7 @@ else:
     isA1111 = False
 
 
-VERSION = "4.0.2"
+VERSION = "4.0.3"
 
 
 class ForgeCouple(scripts.Script):
@@ -97,7 +97,11 @@ class ForgeCouple(scripts.Script):
         return self.is_img2img and len(self.tiles) > 0
 
     @staticmethod
-    def parse_common_prompt(prompt: str, brackets: tuple[str], common_definitions_in_prompt: bool = True) -> str:
+    def parse_common_prompt(
+        prompt: str,
+        brackets: tuple[str],
+        def_in_prompt: bool,
+    ) -> str:
         common_prompts: dict[str, str] = {}
         op, cs = brackets
 
@@ -106,7 +110,7 @@ class ForgeCouple(scripts.Script):
         for m in matches:
             key: str = m.group(1).strip()
             val: str = m.group(2).strip()
-            prompt = prompt.replace(m.group(0), val if common_definitions_in_prompt else "")
+            prompt = prompt.replace(m.group(0), val if def_in_prompt else "")
             common_prompts.update({key: val})
 
         pattern = rf"{op}([^{op}{cs}]+?){cs}"
@@ -137,7 +141,7 @@ class ForgeCouple(scripts.Script):
         mapping: list,
         common_parser: str,
         common_debug: bool,
-        common_definitions_in_prompt: bool,
+        def_in_prompt: bool,
         *args,
         **kwargs,
     ):
@@ -155,7 +159,11 @@ class ForgeCouple(scripts.Script):
         prompts: str = kwargs["prompts"][0]
 
         if common_parser in ("{ }", "< >"):
-            prompts = self.parse_common_prompt(prompts, common_parser.split(" "), common_definitions_in_prompt)
+            prompts = self.parse_common_prompt(
+                prompts,
+                common_parser.split(" "),
+                def_in_prompt,
+            )
             if common_debug:
                 print("")
                 logger.info(f"[Common Prompts Debug]\n{prompts}\n")
@@ -217,6 +225,7 @@ class ForgeCouple(scripts.Script):
             fc_param["forge_couple_background"] = background
             fc_param["forge_couple_background_weight"] = background_weight
         fc_param["forge_couple_common_parser"] = common_parser
+        fc_param["forge_couple_def_in_prompt"] = def_in_prompt
 
         p.extra_generation_params.update(fc_param)
         # ===== Infotext =====

--- a/scripts/forge_couple.py
+++ b/scripts/forge_couple.py
@@ -97,7 +97,7 @@ class ForgeCouple(scripts.Script):
         return self.is_img2img and len(self.tiles) > 0
 
     @staticmethod
-    def parse_common_prompt(prompt: str, brackets: tuple[str]) -> str:
+    def parse_common_prompt(prompt: str, brackets: tuple[str], common_definitions_in_prompt: bool = True) -> str:
         common_prompts: dict[str, str] = {}
         op, cs = brackets
 
@@ -106,7 +106,7 @@ class ForgeCouple(scripts.Script):
         for m in matches:
             key: str = m.group(1).strip()
             val: str = m.group(2).strip()
-            prompt = prompt.replace(m.group(0), val)
+            prompt = prompt.replace(m.group(0), val if common_definitions_in_prompt else "")
             common_prompts.update({key: val})
 
         pattern = rf"{op}([^{op}{cs}]+?){cs}"
@@ -137,6 +137,7 @@ class ForgeCouple(scripts.Script):
         mapping: list,
         common_parser: str,
         common_debug: bool,
+        common_definitions_in_prompt: bool,
         *args,
         **kwargs,
     ):
@@ -154,7 +155,7 @@ class ForgeCouple(scripts.Script):
         prompts: str = kwargs["prompts"][0]
 
         if common_parser in ("{ }", "< >"):
-            prompts = self.parse_common_prompt(prompts, common_parser.split(" "))
+            prompts = self.parse_common_prompt(prompts, common_parser.split(" "), common_definitions_in_prompt)
             if common_debug:
                 print("")
                 logger.info(f"[Common Prompts Debug]\n{prompts}\n")


### PR DESCRIPTION
Added checkbox to include or exclude original common definition *{foo:bar}* to final prompt.